### PR TITLE
Cease excluding ARM64 platforms from Molecule testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,20 +184,6 @@ jobs:
         architecture:
           - amd64
           - arm64
-        exclude:
-          # TODO: systemd-journald.socket fails to start under QEMU
-          # emulation starting with systemd version 256, so starting
-          # with that version the systemd-journald service cannot be
-          # restarted either.  Right now we support this case, but we
-          # can't test it until we have native ARM64 runners.
-          #
-          # See issue #42 for more details.
-          - architecture: arm64
-            platform: debian13-systemd
-          - architecture: arm64
-            platform: fedora41-systemd
-          - architecture: arm64
-            platform: kali-systemd
         platform:
           - amazonlinux2023-systemd
           - debian10-systemd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -85,22 +85,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: systemd-journald.socket fails to start under QEMU emulation
-  # starting with systemd version 256, so starting with that version
-  # the systemd-journald service cannot be restarted either.  Right
-  # now we support this case, but we can't test it until we have
-  # native ARM64 runners.
-  #
-  # See issue #42 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-debian13-ansible:latest
-  #   name: debian13-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the exclusion of ARM64 platforms from Molecule testing.

## 💭 Motivation and context ##

Such exclusions are no longer necessary because we are now using native ARM64 GitHub Actions runners.

This commit resolves #42.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.